### PR TITLE
Correção do link para instação do get-pip.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ aliases:
       command: |
         sudo apt-get update
         sudo apt-get install python3.5-dev
-        curl -O https://bootstrap.pypa.io/get-pip.py
+        curl -O https://bootstrap.pypa.io/3.5/get-pip.py
         python3.5 get-pip.py --user
         pip install awscli --upgrade --user
 


### PR DESCRIPTION
O link de download do get-pip.py mudou, agora ele deve ser o `https://bootstrap.pypa.io/3.5/get-pip.py`